### PR TITLE
Fix the bug in the `h`-string literal calculation.

### DIFF
--- a/server/src/features/codeLens.ts
+++ b/server/src/features/codeLens.ts
@@ -35,9 +35,7 @@ export class CodeLensProvider {
 			if (numberTag === 'H') {
 				result = createHash('sha256').update(text).digest('hex');
 			} else if (numberTag === 'h') {
-				result = createHash('sha256')
-					.update(text).digest()
-					.slice(0, 8).toString('hex');;
+				result = createHash('sha256').update(text).digest().slice(0, 4).toString('hex');
 			} else if (numberTag === 'u') {
 				result = Buffer.from(text).toString('hex');
 			} else if (numberTag === 'c') {


### PR DESCRIPTION
The original calculation results in 64-bit hexadecimal string which is not consistent with the description in TON document.

> `h`—creates an int constant that is the first 32 bits of the SHA256 hash of the string.
> https://docs.ton.org/develop/func/literals_identifiers